### PR TITLE
ci: give each Docker workflow its own gha cache scope

### DIFF
--- a/.github/workflows/docker-fork.yml
+++ b/.github/workflows/docker-fork.yml
@@ -20,6 +20,12 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+# One build per PR; a new push cancels the previous one. Distinct from
+# docker-publish's group so the two never share a cache reservation.
+concurrency:
+  group: docker-fork-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     # Only for fork PRs that carry the review label.
@@ -69,5 +75,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Own scope so a fork build never collides with docker-publish.yml
+          # on the shared GHA cache ("failed to reserve cache").
+          cache-from: type=gha,scope=fork
+          cache-to: type=gha,mode=max,scope=fork

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,12 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
+# Cancel superseded runs on the same ref; also avoids racing docker-fork.yml
+# on the shared GHA cache (see the scoped cache-to below).
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   build:
@@ -84,5 +90,7 @@ jobs:
           push: ${{ github.event.pull_request.head.repo.fork != true }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scoped so this workflow never collides with docker-fork.yml when
+          # both build the same ref concurrently ("failed to reserve cache").
+          cache-from: type=gha,scope=publish
+          cache-to: type=gha,mode=max,scope=publish


### PR DESCRIPTION
## What

Give \`docker-publish.yml\` and \`docker-fork.yml\` distinct GHA build-cache scopes (\`publish\` / \`fork\`), and add a per-workflow \`concurrency\` group that cancels superseded runs.

## Why

On a fork PR both workflows fire and build the same Dockerfile. They shared the default \`type=gha\` cache scope, so their concurrent \`cache-to\` reservations collided:

\`\`\`
ERROR: error writing layer blob: failed to reserve cache
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
\`\`\`

Seen on PR #87 (fork, labeled \`ci: build image\`) — the fork run and the publish build-only run started within ~3s of each other. Scoping the caches removes the collision; the concurrency groups keep only one live build per ref/PR.

## Testing

- Re-run the fork build on a labeled fork PR → build+push succeeds, no cache error.
- Push to \`main\` → publish build succeeds using the \`publish\` cache scope.

AI-assisted change.