### PR TITLE
ci: opt in to fork checkout in docker-fork workflow

### DIFF
--- a/.github/workflows/docker-fork.yml
+++ b/.github/workflows/docker-fork.yml
@@ -42,10 +42,16 @@ jobs:
     steps:
       # Check out the PR head explicitly. pull_request_target defaults to the
       # base ref, so we must pin the fork commit we intend to build and test.
+      # checkout@v7 refuses fork code under pull_request_target by default to
+      # avoid "pwn request" attacks; we opt in because building the fork's code
+      # is the whole point of this job. The compensating control is the
+      # `ci: build image` label gate above: this only runs after a maintainer
+      # has reviewed the diff (Dockerfile/base image) and applied the label.
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435


### PR DESCRIPTION
## What

Set `allow-unsafe-pr-checkout: true` on the checkout step in `docker-fork.yml`.

## Why

`actions/checkout@v7` (bumped by dependabot) now refuses to check out fork PR code under `pull_request_target` by default, as a pwn-request safeguard:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

Building the fork's code is the entire purpose of `docker-fork.yml`, so we opt in explicitly. The compensating control is unchanged: the job is gated behind the `ci: build image` label, so it only runs after a maintainer has reviewed the diff (Dockerfile/base image) and applied the label.

## Testing

- Re-trigger a labeled fork PR (e.g. #87) -> checkout succeeds, build+push of `sha-<commit>` completes.

AI-assisted change.