### PR TITLE
ci: bump buildx/metadata pins in fork workflow to match publish

### DIFF
--- a/.github/workflows/docker-fork.yml
+++ b/.github/workflows/docker-fork.yml
@@ -89,7 +89,7 @@ jobs:
           allow-unsafe-pr-checkout: true
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
@@ -100,7 +100,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # sha of the fork commit only. No moving tags from untrusted code.


### PR DESCRIPTION
## What

Bump `docker/setup-buildx-action` and `docker/metadata-action` pins in `docker-fork.yml` to the same versions already used by `docker-publish.yml`.

## Why

The fork build failed with:

```
error writing layer blob: failed to reserve cache
```

`docker-fork.yml` still pinned the old `setup-buildx-action`, whose buildx can't reserve cache against GitHub's current GHA cache backend. `docker-publish.yml` runs the newer pin and succeeds with the same `type=gha` cache config, so this aligns the two.

## Testing

- Re-label fork PR #87 → build+push of `sha-<commit>` succeeds, no cache error.

AI-assisted change.