### PR TITLE
ci: stop fork build from writing gha cache

### DIFF
--- a/.github/workflows/docker-fork.yml
+++ b/.github/workflows/docker-fork.yml
@@ -116,7 +116,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Own scope so a fork build never collides with docker-publish.yml
-          # on the shared GHA cache ("failed to reserve cache").
-          cache-from: type=gha,scope=fork
-          cache-to: type=gha,mode=max,scope=fork
+          # Read the publish scope's warm layers for speed, but never WRITE
+          # cache from a fork build: the repo GHA cache sits near the 10 GB
+          # limit, so a mode=max export here fails with "failed to reserve
+          # cache". Fork builds are occasional, so read-only cache is enough.
+          cache-from: type=gha,scope=publish


### PR DESCRIPTION
## What

Drop `cache-to` from the fork build; keep a read-only `cache-from` on the `publish` scope.

## Why

The fork build kept failing with:

```
error writing layer blob: failed to reserve cache
```

Root cause is the repo GHA cache quota, not buildx or scopes. Usage sits at **~9.3 GB against GitHub's 10 GB per-repo limit** (143 entries, all from `docker-publish`'s `mode=max` export). The fork build's own `mode=max` `cache-to` can't reserve the space it needs, so the export fails.

Fork builds are occasional, maintainer-gated test builds — they don't need to persist cache. Reading the already-warm `publish` layers keeps them reasonably fast without adding to the quota.

## Testing

- Re-label fork PR #87 → build+push of `sha-<commit>` succeeds, no cache error.

AI-assisted change.